### PR TITLE
Set proper locale to fix crashing with non-ASCII working directories

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,6 +12,8 @@ apps:
   mdl:
     command: mdl
     plugs: [home, removable-media]
+    environment:
+      LANG: C.UTF-8
 
 parts:
   mdl:


### PR DESCRIPTION
Fixes #5.

Signed-off-by: 林博仁(Buo-ren, Lin) <Buo.Ren.Lin@gmail.com>