### PR TITLE
Explicitly set Ruby version

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,7 +10,7 @@ base: core18
 
 apps:
   mdl:
-    command: mdl
+    command: bin/mdl
     plugs: [home, removable-media]
     environment:
       LANG: C.UTF-8
@@ -19,6 +19,7 @@ parts:
   mdl:
     source: https://github.com/markdownlint/markdownlint.git
     plugin: ruby
+    ruby-version: '3.0.2'
     override-pull: |
       snapcraftctl pull
 


### PR DESCRIPTION
This fixes the build failures caused by `chef-utils` depending on newer Ruby.
